### PR TITLE
Documentation (Backend) : encounter level indicated as optional in swagger & prettier configuration

### DIFF
--- a/dd5-generator/.eslintrc.js
+++ b/dd5-generator/.eslintrc.js
@@ -27,6 +27,7 @@ module.exports = {
       'error',
       {
         endOfLine: 'auto',
+        printWidth: 130,
       },
     ],
   },

--- a/dd5-generator/src/main.ts
+++ b/dd5-generator/src/main.ts
@@ -16,9 +16,7 @@ async function bootstrap() {
   // Swagger configuration
   const config = new DocumentBuilder()
     .setTitle('DD5 Generator Documentation')
-    .setDescription(
-      'This application is a treasure generation tool for Dungeon and Dragon 5th edition.',
-    )
+    .setDescription('This application is a treasure generation tool for Dungeon and Dragon 5th edition.')
     .setVersion('1.0')
     .build();
 

--- a/dd5-generator/src/treasureGenerator/__tests__/generator/magic-object.generator.test.ts
+++ b/dd5-generator/src/treasureGenerator/__tests__/generator/magic-object.generator.test.ts
@@ -33,10 +33,7 @@ describe('MagicObjectGenerator', () => {
   });
 
   it('should generate a "Anneau de régénération" from rank 7 when rolled a 11 then a 3', async () => {
-    jest
-      .spyOn(magicObjectGenerator.utils, 'rollDice')
-      .mockReturnValueOnce(11)
-      .mockReturnValueOnce(3);
+    jest.spyOn(magicObjectGenerator.utils, 'rollDice').mockReturnValueOnce(11).mockReturnValueOnce(3);
     const magicObject = await magicObjectGenerator.generateMagicObjectByRank(7);
     expect(magicObject).toBeDefined();
     expect(magicObject).toStrictEqual({
@@ -46,10 +43,7 @@ describe('MagicObjectGenerator', () => {
   });
 
   it('should generate a "Baton de givre" from rank 7 when rolled a 23 then a 6', async () => {
-    jest
-      .spyOn(magicObjectGenerator.utils, 'rollDice')
-      .mockReturnValueOnce(23)
-      .mockReturnValueOnce(6);
+    jest.spyOn(magicObjectGenerator.utils, 'rollDice').mockReturnValueOnce(23).mockReturnValueOnce(6);
     const magicObject = await magicObjectGenerator.generateMagicObjectByRank(7);
     expect(magicObject).toBeDefined();
     expect(magicObject).toStrictEqual({
@@ -59,10 +53,7 @@ describe('MagicObjectGenerator', () => {
   });
 
   it('should generate a "Traité de perspicacité" from rank 7 when rolled a 44 then a 19', async () => {
-    jest
-      .spyOn(magicObjectGenerator.utils, 'rollDice')
-      .mockReturnValueOnce(44)
-      .mockReturnValueOnce(19);
+    jest.spyOn(magicObjectGenerator.utils, 'rollDice').mockReturnValueOnce(44).mockReturnValueOnce(19);
     const magicObject = await magicObjectGenerator.generateMagicObjectByRank(7);
     expect(magicObject).toBeDefined();
     expect(magicObject).toStrictEqual({
@@ -72,10 +63,7 @@ describe('MagicObjectGenerator', () => {
   });
 
   it('should generate a "Sceptre de sécurité" from rank 7 when rolled a 58 then a 4', async () => {
-    jest
-      .spyOn(magicObjectGenerator.utils, 'rollDice')
-      .mockReturnValueOnce(58)
-      .mockReturnValueOnce(4);
+    jest.spyOn(magicObjectGenerator.utils, 'rollDice').mockReturnValueOnce(58).mockReturnValueOnce(4);
     const magicObject = await magicObjectGenerator.generateMagicObjectByRank(7);
     expect(magicObject).toBeDefined();
     expect(magicObject).toStrictEqual({

--- a/dd5-generator/src/treasureGenerator/generator/coin.generator.ts
+++ b/dd5-generator/src/treasureGenerator/generator/coin.generator.ts
@@ -10,18 +10,11 @@ export class CoinGenerator {
   excelUtils = new ExcelUtils();
 
   public async generateCoin(encounterLvl: number): Promise<TreasureItemDto[]> {
-    const coinTable: Row[] = await this.excelUtils.readExcelFile(
-      COIN_FILE_PATH,
-    );
+    const coinTable: Row[] = await this.excelUtils.readExcelFile(COIN_FILE_PATH);
 
-    const { line, column } = this.excelUtils.getGenerationLineAndColumn(
-      encounterLvl,
-      coinTable,
-    );
+    const { line, column } = this.excelUtils.getGenerationLineAndColumn(encounterLvl, coinTable);
     const generationString = coinTable[line][column].toString();
-    console.debug(
-      `Get coin generation for line ${line} and columns ${column}: ${generationString}.`,
-    );
+    console.debug(`Get coin generation for line ${line} and columns ${column}: ${generationString}.`);
     return this.computeCoinGenerationString(generationString).map((name) => ({
       name,
       type: ETreasureType.COIN,
@@ -56,9 +49,7 @@ export class CoinGenerator {
     const coinElement = inputString.split(' ').filter(Boolean);
     // Should contain pair (value, coin)
     if (coinElement.length % 2 !== 0) {
-      console.error(
-        'Error in coin string must be value/coin couple :' + inputString,
-      );
+      console.error('Error in coin string must be value/coin couple :' + inputString);
     }
 
     const res: string[] = [];

--- a/dd5-generator/src/treasureGenerator/generator/individual-treasure.generator.ts
+++ b/dd5-generator/src/treasureGenerator/generator/individual-treasure.generator.ts
@@ -11,8 +11,7 @@ const TREASURE = {
     '50 po': 'Calcédoine, Héliotrope, Jaspe, Onyx, Zircon',
     '100 po': 'Ambre, Améthyste, Grenat, Jade, Perle, Tourmaline',
     '500 po': 'Chrysobéryl, Péridot, Perle noire, Spinelle, Topaze',
-    '1000 po':
-      'Émeraude, Opale noire, Opale de feu, Rubis avec astérisme, Saphir',
+    '1000 po': 'Émeraude, Opale noire, Opale de feu, Rubis avec astérisme, Saphir',
     '5000 po': 'Diamant, Rubis, Saphir noir',
   },
   objet: {
@@ -20,8 +19,7 @@ const TREASURE = {
       "Statuette en os ou en bois rare, Bracelet en or, Calice en or, Petit miroir d'argent, Pendentif en électrum, Portrait d'un noble",
     '250 po':
       "Anneau en platine serti de jaspes, Figurines en ivoire, Couronne d'or et d'argent, Statuette en jade, Tapisserie brodée de fil d'or",
-    '750 po':
-      "Masque cérémoniel en or serti d'ambre, Dague sacrificielle damasquinée de platine, Idole en or aux yeux de perle",
+    '750 po': "Masque cérémoniel en or serti d'ambre, Dague sacrificielle damasquinée de platine, Idole en or aux yeux de perle",
     '2500 po':
       "Pectoral en platine serti d'opales, Gantelet ouvragé en or et argent, Calice en or serti de perles, Sculpture en marbre d'un grand maître",
     '7500 po':
@@ -33,21 +31,12 @@ export class IndividualTreasureGenerator {
   utils = new GeneratorUtils();
   excelUtils = new ExcelUtils();
 
-  async generateIndividualTreasure(
-    encounterLvl: number,
-  ): Promise<TreasureItemDto[]> {
-    const indTreasureTable: Row[] = await this.excelUtils.readExcelFile(
-      INDIVIDUAL_TREASURE_FILE_PATH,
-    );
+  async generateIndividualTreasure(encounterLvl: number): Promise<TreasureItemDto[]> {
+    const indTreasureTable: Row[] = await this.excelUtils.readExcelFile(INDIVIDUAL_TREASURE_FILE_PATH);
 
-    const { line, column } = this.excelUtils.getGenerationLineAndColumn(
-      encounterLvl,
-      indTreasureTable,
-    );
+    const { line, column } = this.excelUtils.getGenerationLineAndColumn(encounterLvl, indTreasureTable);
     const indTreasureString = indTreasureTable[line][column].toString();
-    console.debug(
-      `Get individual treasure generation for line ${line} and columns ${column}: ${indTreasureString}.`,
-    );
+    console.debug(`Get individual treasure generation for line ${line} and columns ${column}: ${indTreasureString}.`);
     return this.computeIndTreasureGenString(indTreasureString);
   }
 
@@ -64,8 +53,7 @@ export class IndividualTreasureGenerator {
     // Get the treasure number
     const treasureNumber: number = this.getIndTreasureNumber(formattedString);
     // Get the treasure type : gems or objects
-    const treasureType: EIndividualTreasureType =
-      this.getIndTreasureType(formattedString);
+    const treasureType: EIndividualTreasureType = this.getIndTreasureType(formattedString);
 
     const res: TreasureItemDto[] = [];
     for (let index = 0; index < treasureNumber; index++) {
@@ -93,24 +81,17 @@ export class IndividualTreasureGenerator {
   }
 
   private getIndTreasureType(inputString: string): EIndividualTreasureType {
-    if (inputString.includes(EIndividualTreasureType.GEMS))
-      return EIndividualTreasureType.GEMS;
-    if (inputString.includes(EIndividualTreasureType.ART_OBJECT))
-      return EIndividualTreasureType.ART_OBJECT;
+    if (inputString.includes(EIndividualTreasureType.GEMS)) return EIndividualTreasureType.GEMS;
+    if (inputString.includes(EIndividualTreasureType.ART_OBJECT)) return EIndividualTreasureType.ART_OBJECT;
 
     return EIndividualTreasureType.UNKNOWN;
   }
 
-  public generateIndTreasureObject(
-    treasureType: EIndividualTreasureType,
-    treasureValue: string,
-  ): TreasureItemDto {
+  public generateIndTreasureObject(treasureType: EIndividualTreasureType, treasureValue: string): TreasureItemDto {
     // Get treasure rewards possible
     const treasurePoolString: string = TREASURE[treasureType][treasureValue];
 
-    const treasurePool: string[] = treasurePoolString
-      .split(',')
-      .filter(Boolean);
+    const treasurePool: string[] = treasurePoolString.split(',').filter(Boolean);
     const randomIndex = this.utils.rollDice(treasurePool.length) - 1; //== RandInt in pool
     const treasureName = treasurePool[randomIndex];
 

--- a/dd5-generator/src/treasureGenerator/generator/magic-object.generator.ts
+++ b/dd5-generator/src/treasureGenerator/generator/magic-object.generator.ts
@@ -80,31 +80,19 @@ export class MagicObjectGenerator {
   utils = new GeneratorUtils();
   excelUtils = new ExcelUtils();
 
-  public async generateMagicObject(
-    encounterLvl: number,
-  ): Promise<TreasureItemDto[]> {
-    const magicObjectDropTable: Row[] = await this.excelUtils.readExcelFile(
-      MAGIC_OBJECT_DROP_PATH,
-    );
+  public async generateMagicObject(encounterLvl: number): Promise<TreasureItemDto[]> {
+    const magicObjectDropTable: Row[] = await this.excelUtils.readExcelFile(MAGIC_OBJECT_DROP_PATH);
 
-    const { line, column } = this.excelUtils.getGenerationLineAndColumn(
-      encounterLvl,
-      magicObjectDropTable,
-    );
+    const { line, column } = this.excelUtils.getGenerationLineAndColumn(encounterLvl, magicObjectDropTable);
     const magicObjectString = magicObjectDropTable[line][column].toString();
-    console.debug(
-      `Get magic object base table generation for line ${line} and columns ${column}: ${magicObjectString}.`,
-    );
+    console.debug(`Get magic object base table generation for line ${line} and columns ${column}: ${magicObjectString}.`);
     // Return magic object Rank array [OMX...]
-    const magicObjToGenerate: EMagicRank[] =
-      this.computeMagicObjectDropString(magicObjectString);
+    const magicObjToGenerate: EMagicRank[] = this.computeMagicObjectDropString(magicObjectString);
 
     return await this.computeMagicObjectsRank(magicObjToGenerate);
   }
 
-  private async computeMagicObjectsRank(
-    magicObjsToGenerate: EMagicRank[],
-  ): Promise<TreasureItemDto[]> {
+  private async computeMagicObjectsRank(magicObjsToGenerate: EMagicRank[]): Promise<TreasureItemDto[]> {
     const validRanks = Object.values(EMagicRank); // ['OM1', 'OM2', ..., 'OM8']
     const res: TreasureItemDto[] = [];
 
@@ -121,9 +109,7 @@ export class MagicObjectGenerator {
     return res;
   }
 
-  public async generateMagicObjectByRank(
-    magicRank: number,
-  ): Promise<TreasureItemDto> {
+  public async generateMagicObjectByRank(magicRank: number): Promise<TreasureItemDto> {
     const magicObjectTable: Row[] = await this.excelUtils.readExcelFile(
       MAGIC_OBJECT_PATH.replace('$', magicRank.toString()), // Get file MOX
     );
@@ -132,15 +118,10 @@ export class MagicObjectGenerator {
     const line = this.excelUtils.getDiceRangeLine(diceRoll, magicObjectTable);
 
     const magicObjectString = magicObjectTable[line][1].toString();
-    console.debug(
-      `Generate rank ${magicRank} magic object for line ${line}: ${magicObjectString}`,
-    );
+    console.debug(`Generate rank ${magicRank} magic object for line ${line}: ${magicObjectString}`);
 
     // Generate magic object categories if needed
-    let generatedString = await this.computeMagicObjItemString(
-      magicObjectString,
-      magicRank,
-    );
+    let generatedString = await this.computeMagicObjItemString(magicObjectString, magicRank);
     // Clean string
     generatedString = this.utils.replaceDiceValue(generatedString);
     generatedString = this.utils.removeAverageInfo(generatedString);
@@ -152,10 +133,7 @@ export class MagicObjectGenerator {
     return EMagicRank[key] || null; // Return the enum value or null if invalid
   }
 
-  private async computeMagicObjItemString(
-    inputString: string,
-    magicRank: number,
-  ): Promise<string> {
+  private async computeMagicObjItemString(inputString: string, magicRank: number): Promise<string> {
     // We need to re-throw on new magic rank
     if (inputString.includes(RETHROW)) {
       const newRankNb = this.getRethrowInfo(inputString);
@@ -168,16 +146,10 @@ export class MagicObjectGenerator {
       return (await this.computeMagicObjectsRank([newMagicRank]))[0].name;
     }
 
-    const magicObjectCategoryInfo = this.getMagicItemCategoryInfo(
-      inputString,
-      magicRank,
-    );
+    const magicObjectCategoryInfo = this.getMagicItemCategoryInfo(inputString, magicRank);
     // If we need to generate a magic item category (like scroll or potions, ect...)
     if (magicObjectCategoryInfo.sheetPage !== -1) {
-      return await this.generateMagicObjectCategory(
-        magicRank,
-        magicObjectCategoryInfo,
-      );
+      return await this.generateMagicObjectCategory(magicRank, magicObjectCategoryInfo);
     }
     return inputString;
   }
@@ -197,9 +169,7 @@ export class MagicObjectGenerator {
     const diceRoll = this.utils.rollDice(subGenInfo.diceFace);
     const line = this.excelUtils.getDiceRangeLine(diceRoll, subGenerationTable);
     const magicItemCategoryString = subGenerationTable[line][1].toString();
-    console.log(
-      `Generate magic object category for line ${line}: ${magicItemCategoryString}`,
-    );
+    console.log(`Generate magic object category for line ${line}: ${magicItemCategoryString}`);
     return magicItemCategoryString;
   }
 
@@ -225,10 +195,7 @@ export class MagicObjectGenerator {
     }
   }
 
-  private getSheetPageOfCategory(
-    inputString: string,
-    magicRank: number,
-  ): number {
+  private getSheetPageOfCategory(inputString: string, magicRank: number): number {
     const pageByCategory = categoryPageByRank[magicRank];
     if (pageByCategory) {
       for (const categoryKey in pageByCategory) {
@@ -266,9 +233,7 @@ export class MagicObjectGenerator {
 
     // Work by pair (X/OMY)
     if (matchNumber.length !== matchMagicRank.length) {
-      console.error(
-        'Error missing number or magic rank in: ' + formattedString,
-      );
+      console.error('Error missing number or magic rank in: ' + formattedString);
     }
 
     const res: EMagicRank[] = [];

--- a/dd5-generator/src/treasureGenerator/generator/rare-object.generator.ts
+++ b/dd5-generator/src/treasureGenerator/generator/rare-object.generator.ts
@@ -1,9 +1,6 @@
 import { Row } from 'read-excel-file/node';
 import { ExcelUtils } from '../utils/excel.utils';
-import {
-  RARE_OBJECT_FILE_PATH,
-  RARE_OBJECT_NB_FILE_PATH,
-} from '../utils/file.const';
+import { RARE_OBJECT_FILE_PATH, RARE_OBJECT_NB_FILE_PATH } from '../utils/file.const';
 import { GeneratorUtils } from '../utils/generator.utils';
 import { TreasureItemDto } from '../dto/treasureItem.dto';
 import { ETreasureType } from '../utils/enum';
@@ -13,17 +10,13 @@ export class RareObjectGenerator {
   excelUtils = new ExcelUtils();
 
   public async generateRareObject(): Promise<TreasureItemDto> {
-    const rareObjectTable: Row[] = await this.excelUtils.readExcelFile(
-      RARE_OBJECT_FILE_PATH,
-    );
+    const rareObjectTable: Row[] = await this.excelUtils.readExcelFile(RARE_OBJECT_FILE_PATH);
 
     const diceRoll = this.utils.rollDice(100);
     const line = this.excelUtils.getDiceRangeLine(diceRoll, rareObjectTable);
 
     const rareObjectString = rareObjectTable[line][1].toString();
-    console.debug(
-      `Get rare object generation for line ${line}: ${rareObjectString}.`,
-    );
+    console.debug(`Get rare object generation for line ${line}: ${rareObjectString}.`);
     return {
       name: this.computeRareObjectGenString(rareObjectString),
       type: ETreasureType.RARE_OBJECT,
@@ -31,24 +24,13 @@ export class RareObjectGenerator {
   }
 
   // Generation in the rare object base table (which give number of rare item)
-  public async generateCompleteRareObjects(
-    encounterLvl: number,
-  ): Promise<TreasureItemDto[]> {
-    const rareObjectDropTable: Row[] = await this.excelUtils.readExcelFile(
-      RARE_OBJECT_NB_FILE_PATH,
-    );
+  public async generateCompleteRareObjects(encounterLvl: number): Promise<TreasureItemDto[]> {
+    const rareObjectDropTable: Row[] = await this.excelUtils.readExcelFile(RARE_OBJECT_NB_FILE_PATH);
 
-    const { line, column } = this.excelUtils.getGenerationLineAndColumn(
-      encounterLvl,
-      rareObjectDropTable,
-    );
+    const { line, column } = this.excelUtils.getGenerationLineAndColumn(encounterLvl, rareObjectDropTable);
 
-    const objectNumber = this.computeRareObjectNbGenString(
-      rareObjectDropTable[line][column].toString(),
-    );
-    console.debug(
-      `Get rare object base table generation for line ${line} and columns ${column}: ${objectNumber} rare object.`,
-    );
+    const objectNumber = this.computeRareObjectNbGenString(rareObjectDropTable[line][column].toString());
+    console.debug(`Get rare object base table generation for line ${line} and columns ${column}: ${objectNumber} rare object.`);
     const res: TreasureItemDto[] = [];
     // Generate X rare object
     for (let i = 0; i < objectNumber; i++) {

--- a/dd5-generator/src/treasureGenerator/generator/treasure.generator.ts
+++ b/dd5-generator/src/treasureGenerator/generator/treasure.generator.ts
@@ -18,48 +18,30 @@ export class TreasureGenerator {
   magicObjectGenerator = new MagicObjectGenerator();
 
   async generateTreasure(encounterLvl: number): Promise<TreasureItemDto[]> {
-    const baseTable: Row[] = await this.excelUtils.readExcelFile(
-      TREASURE_FILE_PATH,
-    );
+    const baseTable: Row[] = await this.excelUtils.readExcelFile(TREASURE_FILE_PATH);
 
-    const { line, column } = this.excelUtils.getGenerationLineAndColumn(
-      encounterLvl,
-      baseTable,
-    );
+    const { line, column } = this.excelUtils.getGenerationLineAndColumn(encounterLvl, baseTable);
     const baseGenString = baseTable[line][column].toString();
-    console.debug(
-      `Get general generation for line ${line} and columns ${column}: ${baseGenString}.`,
-    );
+    console.debug(`Get general generation for line ${line} and columns ${column}: ${baseGenString}.`);
     return this.computeTreasureString(baseGenString, encounterLvl);
   }
 
-  async computeTreasureString(
-    inputString: string,
-    encounterLvl: number,
-  ): Promise<TreasureItemDto[]> {
+  async computeTreasureString(inputString: string, encounterLvl: number): Promise<TreasureItemDto[]> {
     const finalTreasure: TreasureItemDto[] = [];
     if (inputString.includes('A')) {
       const coinGen = await this.coinGenerator.generateCoin(encounterLvl);
       finalTreasure.push(...coinGen);
     }
     if (inputString.includes('B')) {
-      const rareObjGen =
-        await this.rareObjectGenerator.generateCompleteRareObjects(
-          encounterLvl,
-        );
+      const rareObjGen = await this.rareObjectGenerator.generateCompleteRareObjects(encounterLvl);
       finalTreasure.push(...rareObjGen);
     }
     if (inputString.includes('C')) {
-      const indTreasureGen =
-        await this.indTreasureGenerator.generateIndividualTreasure(
-          encounterLvl,
-        );
+      const indTreasureGen = await this.indTreasureGenerator.generateIndividualTreasure(encounterLvl);
       finalTreasure.push(...indTreasureGen);
     }
     if (inputString.includes('D')) {
-      const magicGen = await this.magicObjectGenerator.generateMagicObject(
-        encounterLvl,
-      );
+      const magicGen = await this.magicObjectGenerator.generateMagicObject(encounterLvl);
       finalTreasure.push(...magicGen);
     }
     return finalTreasure;

--- a/dd5-generator/src/treasureGenerator/treasureGenerator.controller.ts
+++ b/dd5-generator/src/treasureGenerator/treasureGenerator.controller.ts
@@ -1,23 +1,11 @@
-import {
-  BadRequestException,
-  Controller,
-  Get,
-  ParseIntPipe,
-  PipeTransform,
-  Query,
-} from '@nestjs/common';
+import { BadRequestException, Controller, Get, ParseIntPipe, PipeTransform, Query } from '@nestjs/common';
 import { TreasureGenerator } from './generator/treasure.generator';
 import { CoinGenerator } from './generator/coin.generator';
 import { MagicObjectGenerator } from './generator/magic-object.generator';
 import { RareObjectGenerator } from './generator/rare-object.generator';
 import { IndividualTreasureGenerator } from './generator/individual-treasure.generator';
 import { GeneratorUtils } from './utils/generator.utils';
-import {
-  ApiOkResponse,
-  ApiOperation,
-  ApiQuery,
-  ApiTags,
-} from '@nestjs/swagger';
+import { ApiOkResponse, ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { TreasureItemDto } from './dto/treasureItem.dto';
 
 class EncounterLevelParser implements PipeTransform {
@@ -62,88 +50,77 @@ export class TreasureGeneratorController {
   @Get()
   @ApiOperation({
     summary: 'General treasure generation',
-    description:
-      'This generates a whole treasure with all sorts of treasure objects.',
+    description: 'Generates a whole treasure with all sorts of treasure objects.',
   })
   @ApiQuery({
     name: 'encounterLevel',
     type: Number,
-    description: 'The level of the encounter to compute the treasure item',
+    required: false,
+    description: 'Level of the encounter to compute a whole treasure (if not provided, a random level will be used)',
   })
   @ApiOkResponse({
     description: 'The generated treasure item array',
     type: TreasureItemDto,
     isArray: true,
   })
-  async getTreasureGeneration(
-    @Query('encounterLevel', EncounterLevelParser) level: number,
-  ): Promise<TreasureItemDto[]> {
+  async getTreasureGeneration(@Query('encounterLevel', EncounterLevelParser) level: number): Promise<TreasureItemDto[]> {
     console.debug(`---------------------------------`);
     const treasure = await this.treasureGenerator.generateTreasure(level);
-    console.debug(
-      `Treasure generation for level ${level}: ${JSON.stringify(treasure)}`,
-    );
+    console.debug(`Treasure generation for level ${level}: ${JSON.stringify(treasure)}`);
     return treasure;
   }
 
   @Get('/coin')
   @ApiOperation({
     summary: 'Coins treasure generation',
-    description: 'This generates coin treasure.',
+    description: 'Generates coin treasure.',
   })
   @ApiQuery({
     name: 'encounterLevel',
     type: Number,
-    description: 'The level of the encounter to compute the treasure item',
+    required: false,
+    description: 'Level of the encounter to compute a coin treasure (if not provided, a random level will be used)',
   })
   @ApiOkResponse({
     description: 'The generated treasure item array',
     type: TreasureItemDto,
     isArray: true,
   })
-  async getCoinGeneration(
-    @Query('encounterLevel', EncounterLevelParser) level: number,
-  ): Promise<TreasureItemDto[]> {
+  async getCoinGeneration(@Query('encounterLevel', EncounterLevelParser) level: number): Promise<TreasureItemDto[]> {
     console.debug(`---------------------------------`);
     const coin = await this.coinGenerator.generateCoin(level);
-    console.debug(
-      `Coin generation for level ${level}: ${JSON.stringify(coin)}`,
-    );
+    console.debug(`Coin generation for level ${level}: ${JSON.stringify(coin)}`);
     return coin;
   }
 
   @Get('/rare-object')
   @ApiOperation({
     summary: 'Rares objects treasure generation',
-    description: 'This generates rares objects treasure.',
+    description: 'Generates rares objects treasure.',
   })
   @ApiQuery({
     name: 'encounterLevel',
     type: Number,
-    description: 'The level of the encounter to compute the treasure item',
+    required: false,
+    description:
+      'Level of the encounter to compute a treasure made of rare objects (if not provided, a random level will be used)',
   })
   @ApiOkResponse({
     description: 'The generated treasure item array',
     type: TreasureItemDto,
     isArray: true,
   })
-  async getRareObjGeneration(
-    @Query('encounterLevel', EncounterLevelParser) level: number,
-  ): Promise<TreasureItemDto[]> {
+  async getRareObjGeneration(@Query('encounterLevel', EncounterLevelParser) level: number): Promise<TreasureItemDto[]> {
     console.debug(`---------------------------------`);
-    const rareObj = await this.rareObjectGenerator.generateCompleteRareObjects(
-      level,
-    );
-    console.debug(
-      `Rare object generation for level ${level}: ${JSON.stringify(rareObj)}`,
-    );
+    const rareObj = await this.rareObjectGenerator.generateCompleteRareObjects(level);
+    console.debug(`Rare object generation for level ${level}: ${JSON.stringify(rareObj)}`);
     return rareObj;
   }
 
   @Get('/rare-object/one')
   @ApiOperation({
     summary: 'Single rare object treasure generation',
-    description: 'This generates one rare object treasure.',
+    description: 'Generates one single rare object',
   })
   @ApiOkResponse({
     description: 'The generated treasure item',
@@ -152,21 +129,20 @@ export class TreasureGeneratorController {
   async getOneRareObjGeneration(): Promise<TreasureItemDto> {
     console.debug(`---------------------------------`);
     const rareObj = await this.rareObjectGenerator.generateRareObject();
-    console.debug(
-      `One rare object generation for level: ${JSON.stringify(rareObj)}`,
-    );
+    console.debug(`One rare object generation for level: ${JSON.stringify(rareObj)}`);
     return rareObj;
   }
 
   @Get('/individual-treasure')
   @ApiOperation({
     summary: 'Individual treasures generation',
-    description: 'This generates individual treasure like gems or art rewards.',
+    description: 'Generates individual treasure like gems or art rewards.',
   })
   @ApiQuery({
     name: 'encounterLevel',
     type: Number,
-    description: 'The level of the encounter to compute the treasure item',
+    required: false,
+    description: 'Level of the encounter to compute individual treasures (if not provided, a random level will be used).',
   })
   @ApiOkResponse({
     description: 'The generated treasure item array',
@@ -177,46 +153,39 @@ export class TreasureGeneratorController {
     @Query('encounterLevel', EncounterLevelParser) level: number,
   ): Promise<TreasureItemDto[]> {
     console.debug(`---------------------------------`);
-    const individualTreasure =
-      await this.indTreasureGenerator.generateIndividualTreasure(level);
-    console.debug(
-      `Individual treasure generation for level ${level}: ${JSON.stringify(
-        individualTreasure,
-      )}`,
-    );
+    const individualTreasure = await this.indTreasureGenerator.generateIndividualTreasure(level);
+    console.debug(`Individual treasure generation for level ${level}: ${JSON.stringify(individualTreasure)}`);
     return individualTreasure;
   }
 
   @Get('/magic-object')
   @ApiOperation({
     summary: 'Magics objects treasure generation',
-    description: 'This generates magics objects.',
+    description: 'Generates magics objects.',
   })
   @ApiQuery({
     name: 'encounterLevel',
     type: Number,
-    description: 'The level of the encounter to compute the treasure item',
+    required: false,
+    description:
+      'Level of the encounter to compute a treasure made of magic objects (if not provided, a random level will be used).',
   })
   @ApiOkResponse({
     description: 'The generated treasure item array',
     type: TreasureItemDto,
     isArray: true,
   })
-  async getMagicObjectGeneration(
-    @Query('encounterLevel', EncounterLevelParser) level: number,
-  ): Promise<TreasureItemDto[]> {
+  async getMagicObjectGeneration(@Query('encounterLevel', EncounterLevelParser) level: number): Promise<TreasureItemDto[]> {
     console.debug(`---------------------------------`);
     const magicObj = await this.magicObjectGenerator.generateMagicObject(level);
-    console.debug(
-      `Magic object generation for level ${level}: ${JSON.stringify(magicObj)}`,
-    );
+    console.debug(`Magic object generation for level ${level}: ${JSON.stringify(magicObj)}`);
     return magicObj;
   }
 
   @Get('/magic-object/rank')
   @ApiOperation({
     summary: 'Magic object treasure generation by rank',
-    description: 'This generates a magic object of the given rank.',
+    description: 'Generates a magic object of the given rank.',
   })
   @ApiQuery({
     name: 'rank',
@@ -227,19 +196,13 @@ export class TreasureGeneratorController {
     description: 'The generated treasure item',
     type: TreasureItemDto,
   })
-  async getRareObjGenerationByRank(
-    @Query('rank', ParseIntPipe) rank: number,
-  ): Promise<TreasureItemDto> {
+  async getRareObjGenerationByRank(@Query('rank', ParseIntPipe) rank: number): Promise<TreasureItemDto> {
     if (rank <= 0 || rank >= 9) {
       throw new BadRequestException('Magic rank must be between 0 and 9');
     }
     console.debug(`---------------------------------`);
-    const magicObj = await this.magicObjectGenerator.generateMagicObjectByRank(
-      rank,
-    );
-    console.debug(
-      `Magic object generation of rank ${rank}: ${JSON.stringify(magicObj)}`,
-    );
+    const magicObj = await this.magicObjectGenerator.generateMagicObjectByRank(rank);
+    console.debug(`Magic object generation of rank ${rank}: ${JSON.stringify(magicObj)}`);
     return magicObj;
   }
 }

--- a/dd5-generator/src/treasureGenerator/utils/excel.utils.ts
+++ b/dd5-generator/src/treasureGenerator/utils/excel.utils.ts
@@ -8,10 +8,7 @@ export class ExcelUtils {
     return await readXlsxFile(path, { sheet: sheetPage });
   }
 
-  getGenerationLineAndColumn(
-    encounterLvl: number,
-    table: Row[],
-  ): { line: number; column: number } {
+  getGenerationLineAndColumn(encounterLvl: number, table: Row[]): { line: number; column: number } {
     // All dice roll are 20 faces
     const diceRoll = this.utils.rollDice(20);
 
@@ -31,9 +28,7 @@ export class ExcelUtils {
         return index;
       }
     }
-    console.error(
-      'No encounter level range was found for encounter level: ' + encounterLvl,
-    );
+    console.error('No encounter level range was found for encounter level: ' + encounterLvl);
     return -1;
   }
 

--- a/dd5-generator/src/treasureGenerator/utils/file.const.ts
+++ b/dd5-generator/src/treasureGenerator/utils/file.const.ts
@@ -1,13 +1,8 @@
-export const TREASURE_FILE_PATH =
-  './src/treasureGenerator/files/treasureGen.xlsx';
+export const TREASURE_FILE_PATH = './src/treasureGenerator/files/treasureGen.xlsx';
 export const COIN_FILE_PATH = './src/treasureGenerator/files/coinGen.xlsx';
-export const RARE_OBJECT_FILE_PATH =
-  './src/treasureGenerator/files/rareObjectGen.xlsx';
-export const RARE_OBJECT_NB_FILE_PATH =
-  './src/treasureGenerator/files/rareObjectNbGen.xlsx';
-export const INDIVIDUAL_TREASURE_FILE_PATH =
-  './src/treasureGenerator/files/individualTreasureGen.xlsx';
-export const MAGIC_OBJECT_DROP_PATH =
-  './src/treasureGenerator/files/magicObjectDrop.xlsx';
+export const RARE_OBJECT_FILE_PATH = './src/treasureGenerator/files/rareObjectGen.xlsx';
+export const RARE_OBJECT_NB_FILE_PATH = './src/treasureGenerator/files/rareObjectNbGen.xlsx';
+export const INDIVIDUAL_TREASURE_FILE_PATH = './src/treasureGenerator/files/individualTreasureGen.xlsx';
+export const MAGIC_OBJECT_DROP_PATH = './src/treasureGenerator/files/magicObjectDrop.xlsx';
 // Need to be replace by code
 export const MAGIC_OBJECT_PATH = './src/treasureGenerator/files/MO$.xlsx';

--- a/dd5-generator/src/treasureGenerator/utils/generator.utils.ts
+++ b/dd5-generator/src/treasureGenerator/utils/generator.utils.ts
@@ -48,9 +48,7 @@ export class GeneratorUtils {
     while ((match = infoRegex.exec(resString)) != null) {
       const position = match.index;
       // Remove the (XXX) in the string
-      resString =
-        resString.substring(0, position) +
-        resString.substring(position + 1 + match[0].length); // +1 for remove space after (XX)
+      resString = resString.substring(0, position) + resString.substring(position + 1 + match[0].length); // +1 for remove space after (XX)
     }
     return resString;
   }


### PR DESCRIPTION
# Description

The encounter level parser accepts [undefined value](https://github.com/Y-YDev/DD5-Generator/blob/e33fe4ce2fa46fc137c0ce3b757d7e9b20a54469/dd5-generator/src/treasureGenerator/treasureGenerator.controller.ts#L36) while the query parameter is mandatory in the swagger documentation.

# Done

- The query parameter is now indicated as optional (`required: false`) 
- The Prettier `printWidth` is set to `130` (instead of the default `80`) to avoid an overly strict and cumbersome line-break policy.